### PR TITLE
Adds initial .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Visual Studio
+.vs/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build artifacts
+[Bb]in/
+[Oo]bj/
+[Rr]elease/
+[Dd]ebug/
+publish/
+*.pdb
+*.exe
+*.dll
+*.exe.config
+*.dll.config
+*.nupkg
+*.snupkg
+*.symbols.nupkg
+
+# Rider
+.idea/
+
+# User-specific files
+*.DS_Store
+Thumbs.db
+
+# Test results
+TestResults/
+*.trx
+*.coverlet.json
+
+# Environment files
+.env
+.vscode
+# NuGet packages folder - typically restored and not committed
+packages/
+
+# Log files
+*.log
+
+# Local History for Visual Studio
+.localhistory/
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Output folder from Inno Setup (if generated locally)
+Output/
+
+# Staging area from release workflow (if created locally)
+staging_area/


### PR DESCRIPTION
Adds a comprehensive .gitignore file to exclude common build artifacts, IDE configuration files, user-specific settings, test results, and other environment-specific files. This helps keep the repository clean and prevents accidental commits of sensitive or unnecessary files.