### PR TITLE
Removes default entry point filtering

### DIFF
--- a/merz_src/Program.cs
+++ b/merz_src/Program.cs
@@ -213,7 +213,7 @@ namespace merz
 
         static List<EntryPoint> CollectEntryPmSpryToolsEntryPoints()
         {
-            var args = new List<string> { "Haulage", "Landform", "Design", "Scheduling" };
+            var args = new List<string> { };
             var allEntryPoints = new List<EntryPoint>();
             Assembly mainAssembly = _currentAssembly ?? Assembly.GetExecutingAssembly();
 
@@ -254,11 +254,6 @@ namespace merz
                 Console.WriteLine("Filtering entry points by groups: " + string.Join(", ", args));
                 filteredEntryPoints = allEntryPoints.Where(ep => args.Contains(ep.group));
             }
-
-            // if (!filteredEntryPoints.Any())
-            // {
-            //     Console.WriteLine("No entry points found after scanning and filtering. The UI might be blank.");
-            // }
 
             return filteredEntryPoints.GroupBy(ep => $"{ep.group}_{ep.name}_{ep.subname}").Select(g => g.First()).ToList();
         }


### PR DESCRIPTION
Removes the default filtering of entry points based on predefined arguments. This change allows the application to load all entry points, deferring the filtering logic to a later stage or different component.